### PR TITLE
chore: use latest version (v1.0.1) of the action in the repo

### DIFF
--- a/.github/workflows/dependabot.scheduled.yml
+++ b/.github/workflows/dependabot.scheduled.yml
@@ -19,7 +19,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: 'Dependabot Batcher'
-        uses: Legal-and-General/dependabot-batcher@v1.0.0
+        uses: Legal-and-General/dependabot-batcher@v1.0.1
         with:
           token: ${{ secrets.DEPENDABOT_BATCH_TOKEN }}
           baseBranchName: 'main'


### PR DESCRIPTION
# Description

Updates the repo to use the [latest release](https://github.com/Legal-and-General/dependabot-batcher/releases/tag/v1.0.1)